### PR TITLE
FRA-284 skill do podstawowej konfiguracji nx

### DIFF
--- a/packages/shared/claude-plugins/src/plugins/smart/skills/scaffold-nx-workspace/SKILL.md
+++ b/packages/shared/claude-plugins/src/plugins/smart/skills/scaffold-nx-workspace/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: scaffold-nx-workspace
+description: Scaffold a generic base Nx + Angular SSR workspace in smartsoft001 style by wrapping create-nx-workspace and patching configs. Use whenever the user wants to bootstrap, scaffold, initialize, or set up a NEW smartsoft Nx monorepo / Angular SSR app workspace, or asks for the "podstawowa konfiguracja nx" / base workspace config. Scaffolds ONLY the generic toolchain plus a base SSR app and a base shared lib — no feature modules and no feature npm packages.
+user-invocable: true
+allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
+---
+
+# Scaffold Nx Workspace
+
+Bootstrap a base Nx + Angular SSR monorepo in smartsoft001 style: wrap `create-nx-workspace`,
+then patch the generated files to the conventions below. The result is a **buildable empty
+shell** — one SSR app (`apps/web`) and one shared lib (`libs/shared/angular`) — ready for the
+feature-module skills to extend.
+
+## Conventions (nx build & architecture only)
+
+This skill enforces only the build and architecture conventions.
+
+- **Toolchain:** npm + Nx + an Angular SSR app built with `@angular/build:application` (esbuild),
+  `outputMode: server`; Jest (jest-preset-angular, zoneless env) for unit tests, Playwright for e2e.
+  **Versions are never hardcoded** — the Angular version is inferred from the installed
+  `@smartsoft001/angular` library, confirmed with the user, and Nx / Node / the rest are derived to
+  match (see Step 1).
+- **Caching / affected:** `targetDefaults` cache `build`/`lint`/`jest`; `nx.json` sets `defaultBase`
+  for `nx affected`. No Nx Cloud binding.
+- **Lint / format:** ESLint flat config (`eslint.config.mjs`) with `import/order` + an `@<prefix>/**`
+  pathGroup; Prettier (`singleQuote`); husky + commitlint (conventional commits, scopes from `libs/`).
+- **Layout:** monorepo with `apps/` (the SSR `web` app) and `libs/`. Shared lib at `libs/shared/angular`,
+  aliased `@<prefix>/angular`. Feature code lives in separate libs (`libs/<feature>/...`) added by the
+  module skills — never here.
+- **Style:** `scss` everywhere — the app, generated libs, and generated components all default to `scss`.
+- **SSR runtime env:** `EnvironmentService` (in the shared lib) + a `/env.js` endpoint + an `env-init.ts`
+  imported first in `main.server.ts`.
+
+## Scope
+
+**Scaffolds:** workspace config (nx / tsconfig / eslint / jest / prettier / husky / commitlint / `.nvmrc`),
+the `apps/web` SSR shell, the `libs/shared/angular` skeleton, a generic `.claude` baseline, and toolchain
+`package.json` deps.
+
+**Hard boundary — does NOT scaffold:** feature modules / domains, feature npm packages, or module-coupled
+components. Stop at the buildable shell and defer those to the feature-module skills.
+
+## When to use / not use
+
+- **Use for:** bootstrapping a new smartsoft Nx / Angular-SSR workspace, "podstawowa konfiguracja nx", a no-modules skeleton.
+- **Not for:** adding a feature lib/module (→ module skills), adding feature deps, reconfiguring an existing
+  workspace's lint/format (→ `/smart:format-code`), or component API questions (→ `smart:angular-components-*`).
+
+## Steps
+
+1. **Resolve & confirm versions** — the Angular version anchors everything else (see
+   `references/version-resolution.md`):
+   - Detect the Angular version `@smartsoft001/angular` targets:
+     `npm view @smartsoft001/angular peerDependencies.@angular/core` (fall back to
+     `dependencies.@angular/core`; or read its installed `package.json`). Take `<NG_VERSION>` / `<NG_MAJOR>`.
+   - Confirm with `AskUserQuestion`: "Use Angular `<NG_VERSION>` (matches @smartsoft001/angular)? — or type another version."
+   - Derive the rest: `<NX_LINE>` = `^<NG_MAJOR + 1>` (Nx major tracks Angular major + 1, e.g. Angular 21 → Nx 22; verify with `npm view nx@<NX_LINE> version`); `<NODE_VERSION>` = an LTS within `@angular/core@<NG_VERSION>` `engines.node`. Everything else is whatever `create-nx-workspace@<NX_LINE>` installs — not pinned.
+2. **Prefix** — run `scripts/derive-prefix.sh <folder>`, present the candidate via `AskUserQuestion`,
+   require confirm/override. Hold as `<PREFIX>` (threaded into tsconfig paths, eslint, imports, package names).
+3. **Base branch** — confirm `<BASE_BRANCH>` for `nx.json` `defaultBase` + husky pre-push (default `origin/development`).
+4. **Create** — run:
+   ```bash
+   npx --yes create-nx-workspace@<NX_LINE> <name> \
+     --preset=angular-monorepo --appName=web --style=scss --ssr \
+     --e2eTestRunner=playwright --unitTestRunner=jest \
+     --packageManager=npm --nxCloud=skip --interactive=false
+   ```
+   Use `--interactive=false` (not `--no-interactive`); `--nxCloud=skip`; no `--bundler` (Angular's builder
+   is esbuild by default). `CLAUDECODE=1` forces non-interactive NDJSON output. Then verify the build executor
+   is `@angular/build:application`, and if the bundled Angular differs from `<NG_VERSION>`, align `@angular/*` in Step 5.
+5. **Patch config** — apply `references/patch-delta.md`, threading `<PREFIX>` / `<BASE_BRANCH>` / `<NG_VERSION>` / `<NODE_VERSION>`.
+6. **App + lib** — patch `apps/web` per `references/base-app.md`; generate then patch `libs/shared/angular`
+   per `references/base-shared-lib.md`.
+7. **.claude baseline** — write per `references/base-claude-config.md`.
+8. **Install (gated)** — ask before `npm install`; skip during self-validation.
+9. **Verify** — run `scripts/verify-scaffold.sh <name> <PREFIX>`; fix and re-run until it passes.
+
+## Notes
+
+- Prerequisites: nvm + npm and an empty target directory. The Node version is derived in Step 1
+  (`.nvmrc` ← `<NODE_VERSION>`), not fixed by this skill.
+- Bundled `references/` + `scripts/` ship automatically (the whole `src/plugins/**` tree is copied to dist).
+  Do NOT hand-edit `plugin.json` version — it is auto-synced at build time.

--- a/packages/shared/claude-plugins/src/plugins/smart/skills/scaffold-nx-workspace/references/base-app.md
+++ b/packages/shared/claude-plugins/src/plugins/smart/skills/scaffold-nx-workspace/references/base-app.md
@@ -1,0 +1,405 @@
+# Base SSR app — `apps/web`
+
+`create-nx-workspace --ssr` emits the SSR skeleton. Patch it to the generic shell below,
+stripping all feature/business logic. Substitute `<PREFIX>`.
+
+The base app keeps the SSR Express server, a runtime-env endpoint (`/env.js`), the SSRF
+host allow-list, a minimal standalone `App`, and a catch-all server route. It depends on
+`EnvironmentService` + `environment` from `@<PREFIX>/angular` (see `base-shared-lib.md`) —
+this base-app↔base-lib coupling is intentional generic SSR infra.
+
+---
+
+## `apps/web/project.json` (overwrite)
+
+Drop feature `scripts` (e.g. masonry) and prod `fileReplacements` only if the base lib provides
+`environment.prod.ts` (it does — keep the fileReplacement). Keep build/serve/test/lint/serve-static.
+
+```json
+{
+  "name": "web",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "projectType": "application",
+  "prefix": "app",
+  "sourceRoot": "apps/web/src",
+  "tags": [],
+  "targets": {
+    "build": {
+      "executor": "@angular/build:application",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "outputPath": "dist/apps/web",
+        "browser": "apps/web/src/main.ts",
+        "polyfills": [],
+        "tsConfig": "apps/web/tsconfig.app.json",
+        "assets": [
+          { "glob": "**/*", "input": "apps/web/public", "output": "/" }
+        ],
+        "styles": ["apps/web/src/styles.scss"],
+        "server": "apps/web/src/main.server.ts",
+        "ssr": { "entry": "apps/web/src/server.ts" },
+        "outputMode": "server"
+      },
+      "configurations": {
+        "production": {
+          "fileReplacements": [
+            {
+              "replace": "libs/shared/angular/src/lib/environments/environment.ts",
+              "with": "libs/shared/angular/src/lib/environments/environment.prod.ts"
+            }
+          ],
+          "budgets": [
+            {
+              "type": "initial",
+              "maximumWarning": "2mb",
+              "maximumError": "4mb"
+            },
+            {
+              "type": "anyComponentStyle",
+              "maximumWarning": "4kb",
+              "maximumError": "16kb"
+            }
+          ],
+          "outputHashing": "all",
+          "optimization": true
+        },
+        "development": {
+          "optimization": false,
+          "extractLicenses": false,
+          "sourceMap": true
+        }
+      },
+      "defaultConfiguration": "production"
+    },
+    "serve": {
+      "continuous": true,
+      "executor": "@angular/build:dev-server",
+      "options": { "port": 4210 },
+      "configurations": {
+        "production": { "buildTarget": "web:build:production" },
+        "development": { "buildTarget": "web:build:development" }
+      },
+      "defaultConfiguration": "development"
+    },
+    "extract-i18n": {
+      "executor": "@angular/build:extract-i18n",
+      "options": { "buildTarget": "web:build" }
+    },
+    "lint": { "executor": "@nx/eslint:lint" },
+    "test": {
+      "executor": "@nx/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "jestConfig": "apps/web/jest.config.ts",
+        "tsConfig": "apps/web/tsconfig.spec.json"
+      }
+    },
+    "serve-static": {
+      "continuous": true,
+      "executor": "@nx/web:file-server",
+      "options": {
+        "buildTarget": "web:build",
+        "port": 4210,
+        "staticFilePath": "dist/apps/web/browser",
+        "spa": true
+      }
+    }
+  }
+}
+```
+
+---
+
+## `apps/web/src/env-init.ts` (create)
+
+```ts
+/**
+ * Environment initialization for server-side rendering.
+ *
+ * This file MUST be imported FIRST in main.server.ts to ensure
+ * environment variables are loaded from process.env BEFORE any
+ * modules that depend on them are evaluated.
+ */
+import { EnvironmentService } from '@<PREFIX>/angular';
+
+EnvironmentService.initFromProcessEnv();
+```
+
+## `apps/web/src/main.server.ts` (overwrite)
+
+```ts
+/**
+ * CRITICAL: './env-init' MUST be the first import!
+ * It initializes environment variables from process.env BEFORE
+ * any modules that depend on them are evaluated.
+ */
+import './env-init';
+
+import {
+  BootstrapContext,
+  bootstrapApplication,
+} from '@angular/platform-browser';
+
+import { App } from './app/app';
+import { config } from './app/app.config.server';
+
+const bootstrap = (context: BootstrapContext) =>
+  bootstrapApplication(App, config, context);
+
+export default bootstrap;
+```
+
+## `apps/web/src/main.ts` (keep create-nx-workspace default)
+
+```ts
+import { bootstrapApplication } from '@angular/platform-browser';
+
+import { App } from './app/app';
+import { appConfig } from './app/app.config';
+
+bootstrapApplication(App, appConfig).catch((err) => console.error(err));
+```
+
+---
+
+## `apps/web/src/server.ts` (overwrite — generic)
+
+Generic Express + `AngularNodeAppEngine` with SSRF host allow-list and the `/env.js`
+runtime-env endpoint. **Drop** any feature endpoints (e.g. a `/api/translations` handler) and
+extra env keys beyond `API_URL` / `SITE_URL` / `APP_VERSION`.
+
+```ts
+import {
+  AngularNodeAppEngine,
+  createNodeRequestHandler,
+  isMainModule,
+  writeResponseToNodeResponse,
+} from '@angular/ssr/node';
+import { config } from 'dotenv';
+import express from 'express';
+
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+config({ path: resolve(process.cwd(), '.env') });
+
+const serverDistFolder = dirname(fileURLToPath(import.meta.url));
+const browserDistFolder = resolve(serverDistFolder, '../browser');
+
+const app = express();
+
+// Build allowed hosts from SITE_URL and API_URL for SSR SSRF protection
+const allowedHosts: string[] = [];
+const siteUrl = process.env['SITE_URL'];
+if (siteUrl) {
+  try {
+    const host = new URL(
+      siteUrl.startsWith('http') ? siteUrl : `https://${siteUrl}`,
+    ).hostname;
+    allowedHosts.push(host);
+    if (host.startsWith('www.')) {
+      allowedHosts.push(host.slice(4));
+    } else {
+      allowedHosts.push(`www.${host}`);
+    }
+  } catch {
+    // ignore invalid URL
+  }
+}
+const apiUrl = process.env['API_URL'];
+if (apiUrl) {
+  try {
+    allowedHosts.push(
+      new URL(apiUrl.startsWith('http') ? apiUrl : `https://${apiUrl}`)
+        .hostname,
+    );
+  } catch {
+    // ignore invalid URL
+  }
+}
+
+// In development/CI, allow localhost for SSR rendering
+if (allowedHosts.length === 0 || process.env['NODE_ENV'] !== 'production') {
+  allowedHosts.push('localhost');
+}
+
+const angularApp = new AngularNodeAppEngine({ allowedHosts });
+
+app.get('/env.js', (req, res) => {
+  const envTemplate = `(function (window) {
+  window['env'] = window['env'] || {};
+
+  // Environment variables
+  window['env']['apiUrl'] = '\${API_URL}';
+  window['env']['siteUrl'] = '\${SITE_URL}';
+  window['env']['version'] = '\${APP_VERSION}';
+})(this);`;
+
+  const envConfig = envTemplate
+    .replace(/\$\{API_URL\}/g, process.env['API_URL'] || '')
+    .replace(/\$\{SITE_URL\}/g, process.env['SITE_URL'] || '')
+    .replace(/\$\{APP_VERSION\}/g, process.env['APP_VERSION'] || '');
+
+  res.setHeader('Content-Type', 'application/javascript; charset=utf-8');
+  res.setHeader('Cache-Control', 'no-cache, no-store, must-revalidate');
+  res.send(envConfig);
+});
+
+/**
+ * Serve static files from /browser
+ */
+app.use(
+  express.static(browserDistFolder, {
+    maxAge: '1y',
+    index: false,
+    redirect: false,
+  }),
+);
+
+/**
+ * Handle all other requests by rendering the Angular application.
+ */
+app.use('/**', (req, res, next) => {
+  angularApp
+    .handle(req)
+    .then((response) =>
+      response ? writeResponseToNodeResponse(response, res) : next(),
+    )
+    .catch(next);
+});
+
+/**
+ * Start the server if this module is the main entry point.
+ */
+if (isMainModule(import.meta.url)) {
+  const port = process.env['PORT'] || 4000;
+  app.listen(port, () => {
+    console.log(`Node Express server listening on http://localhost:${port}`);
+  });
+}
+
+/**
+ * Request handler used by the Angular CLI (for dev-server and during build).
+ */
+export const reqHandler = createNodeRequestHandler(app);
+```
+
+---
+
+## `apps/web/src/app/app.config.ts` (overwrite — minimal)
+
+Strip ngrx / translate / masonry / feature modules. Keep zoneless + hydration + router +
+http + the `EnvironmentService` initializer.
+
+```ts
+import {
+  provideHttpClient,
+  withFetch,
+  withInterceptorsFromDi,
+} from '@angular/common/http';
+import {
+  ApplicationConfig,
+  inject,
+  isDevMode,
+  provideBrowserGlobalErrorListeners,
+  provideEnvironmentInitializer,
+  provideZonelessChangeDetection,
+} from '@angular/core';
+import {
+  provideClientHydration,
+  withEventReplay,
+} from '@angular/platform-browser';
+import { provideRouter, withInMemoryScrolling } from '@angular/router';
+
+import { EnvironmentService } from '@<PREFIX>/angular';
+
+import { appRoutes } from './app.routes';
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideClientHydration(withEventReplay()),
+    provideBrowserGlobalErrorListeners(),
+    provideZonelessChangeDetection(),
+    provideRouter(
+      appRoutes,
+      withInMemoryScrolling({ scrollPositionRestoration: 'top' }),
+    ),
+    provideHttpClient(withFetch(), withInterceptorsFromDi()),
+    provideEnvironmentInitializer(() => {
+      const envService = inject(EnvironmentService);
+      envService.init();
+    }),
+  ],
+};
+```
+
+## `apps/web/src/app/app.config.server.ts` (keep create-nx-workspace default)
+
+```ts
+import { mergeApplicationConfig, ApplicationConfig } from '@angular/core';
+import { provideServerRendering, withRoutes } from '@angular/ssr';
+
+import { appConfig } from './app.config';
+import { serverRoutes } from './app.routes.server';
+
+const serverConfig: ApplicationConfig = {
+  providers: [provideServerRendering(withRoutes(serverRoutes))],
+};
+
+export const config = mergeApplicationConfig(appConfig, serverConfig);
+```
+
+## `apps/web/src/app/app.routes.server.ts` (overwrite — catch-all only)
+
+```ts
+import { RenderMode, ServerRoute } from '@angular/ssr';
+
+export const serverRoutes: ServerRoute[] = [
+  {
+    path: '**',
+    renderMode: RenderMode.Server,
+  },
+];
+```
+
+## `apps/web/src/app/app.routes.ts` (overwrite — empty)
+
+```ts
+import { Route } from '@angular/router';
+
+export const appRoutes: Route[] = [];
+```
+
+## `apps/web/src/app/app.ts` (overwrite — minimal shell)
+
+```ts
+import { Component } from '@angular/core';
+import { RouterModule } from '@angular/router';
+
+@Component({
+  imports: [RouterModule],
+  selector: 'app-root',
+  templateUrl: './app.html',
+  styleUrl: './app.scss',
+})
+export class App {}
+```
+
+## `apps/web/src/app/app.html` (overwrite — minimal)
+
+```html
+<router-outlet></router-outlet>
+```
+
+---
+
+## Files to keep as create-nx-workspace emitted them
+
+`apps/web/src/styles.scss`, `apps/web/src/index.html`, `apps/web/src/test-setup.ts`,
+`apps/web/src/app/app.scss`, `apps/web/tsconfig.app.json`, `apps/web/tsconfig.spec.json`,
+`apps/web/tsconfig.json`, `apps/web/eslint.config.mjs`, `apps/web/jest.config.ts`,
+`apps/web/public/**`.
+
+> If `apps/web/jest.config.ts` carries a feature `moduleNameMapper` or a feature-scoped
+> `transformIgnorePatterns` entry, strip it to a generic
+> `transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)']`.

--- a/packages/shared/claude-plugins/src/plugins/smart/skills/scaffold-nx-workspace/references/base-claude-config.md
+++ b/packages/shared/claude-plugins/src/plugins/smart/skills/scaffold-nx-workspace/references/base-claude-config.md
@@ -1,0 +1,188 @@
+# Base `.claude` config
+
+Seed the **generic** baseline only. Drop `flow@mobilems` and all project-specific
+permissions/MCP allow-lists from the reference. Substitute `<WORKSPACE_NAME>`.
+
+---
+
+## `.claude/settings.json` (create)
+
+The smart-plugin hooks resolve from `node_modules/@smartsoft001/claude-plugins/...`
+(added to devDeps in `patch-delta.md`).
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "Bash(nx:*)",
+      "Bash(npx nx:*)",
+      "Bash(npm run format:*)",
+      "Bash(source:*)",
+      "Bash(nvm use:*)",
+      "Bash(git status:*)",
+      "Bash(git diff:*)",
+      "Bash(git log:*)",
+      "Bash(git show:*)",
+      "Bash(git add:*)",
+      "Bash(git fetch:*)",
+      "Bash(ls:*)",
+      "Bash(find:*)",
+      "Bash(grep:*)"
+    ],
+    "deny": [],
+    "ask": ["Bash(git commit:*)", "Bash(git push:*)", "Bash(gh pr create:*)"]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash|Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node_modules/@smartsoft001/claude-plugins/plugins/smart/hooks/safety_validator.py"
+          }
+        ]
+      },
+      {
+        "matcher": "Read|Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "FILE=$(jq -r '.tool_input.file_path // empty'); echo \"$FILE\" | grep -qE '(\\.env|secrets|credentials)' && { echo \"BLOCKED: Access denied to sensitive file: $FILE\" >&2; exit 2; } || exit 0"
+          }
+        ]
+      },
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node_modules/@smartsoft001/claude-plugins/plugins/smart/hooks/audit_logger.py"
+          }
+        ]
+      },
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node_modules/@smartsoft001/claude-plugins/plugins/smart/hooks/skill_validator.py"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "source ~/.nvm/nvm.sh && nvm use 24 && npm run format"
+          }
+        ]
+      },
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node_modules/@smartsoft001/claude-plugins/plugins/smart/hooks/audit_logger.py"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node_modules/@smartsoft001/claude-plugins/plugins/smart/hooks/audit_logger.py"
+          }
+        ]
+      }
+    ]
+  },
+  "enabledPlugins": {
+    "smart@smartsoft": true,
+    "nx@nx-claude-plugins": true
+  },
+  "extraKnownMarketplaces": {
+    "nx-claude-plugins": {
+      "source": {
+        "source": "github",
+        "repo": "nrwl/nx-ai-agents-config"
+      }
+    }
+  },
+  "env": {
+    "CLAUDE_CODE_FORK_SUBAGENT": "1",
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+  }
+}
+```
+
+> The mobilems module skills (the `flow@mobilems` plugin) are added to `enabledPlugins`
+> and the project-specific permissions are grown when those skills run — not here.
+
+---
+
+## `AGENTS.md` (create — generic Nx block, verbatim-usable)
+
+```md
+<!-- nx configuration start-->
+<!-- Leave the start & end comments to automatically receive updates. -->
+
+# General Guidelines for working with Nx
+
+- For navigating/exploring the workspace, invoke the `nx-workspace` skill first - it has patterns for querying projects, targets, and dependencies
+- When running tasks (for example build, lint, test, e2e, etc.), always prefer running the task through `nx` (i.e. `nx run`, `nx run-many`, `nx affected`) instead of using the underlying tooling directly
+- Prefix nx commands with the workspace's package manager (e.g., `npm exec nx build`) - avoids using globally installed CLI
+- You have access to the Nx MCP server and its tools, use them to help the user
+- For Nx plugin best practices, check `node_modules/@nx/<plugin>/PLUGIN.md`. Not all plugins have this file - proceed without it if unavailable.
+- NEVER guess CLI flags - always check nx_docs or `--help` first when unsure
+
+## Scaffolding & Generators
+
+- For scaffolding tasks (creating apps, libs, project structure, setup), ALWAYS invoke the `nx-generate` skill FIRST before exploring or calling MCP tools
+
+## When to use nx_docs
+
+- USE for: advanced config options, unfamiliar flags, migration guides, plugin configuration, edge cases
+- DON'T USE for: basic generator syntax (`nx g @nx/react:app`), standard commands, things you already know
+- The `nx-generate` skill handles generator discovery internally - don't call nx_docs just to look up generator syntax
+
+<!-- nx configuration end-->
+```
+
+---
+
+## `CLAUDE.md` (create — trimmed generic skeleton)
+
+```md
+# CLAUDE.md
+
+Guidance for Claude Code when working in the **<WORKSPACE_NAME>** workspace.
+
+## Project Overview
+
+Nx + Angular SSR monorepo scaffolded with the smartsoft `scaffold-nx-workspace` skill.
+A base shell only — feature modules are added by the mobilems module skills.
+
+## Structure
+
+- `apps/web` — Angular SSR app (Express server + runtime-env).
+- `libs/shared/angular` — shared library (`@<PREFIX>/angular`).
+
+## Conventions
+
+- **Node** per `.nvmrc` via nvm; npm package manager.
+- Run tasks through Nx: `nx build`, `nx test`, `nx lint`, `nx serve web`.
+- Format with `/smart:format-code` (Prettier + ESLint flat config, `eslint.config.mjs`).
+- Conventional commits (commitlint); husky pre-push runs affected lint/test/build.
+- For smartsoft conventions, see the `/smart:project-conventions` skill.
+
+## Boundaries
+
+- Styling defaults to **scss** everywhere (app, libs, and components).
+- Do not add feature npm packages or feature modules by hand — use the module skills.
+```

--- a/packages/shared/claude-plugins/src/plugins/smart/skills/scaffold-nx-workspace/references/base-shared-lib.md
+++ b/packages/shared/claude-plugins/src/plugins/smart/skills/scaffold-nx-workspace/references/base-shared-lib.md
@@ -1,0 +1,288 @@
+# Base shared lib — `libs/shared/angular`
+
+Generate the library then patch it to the generic skeleton below. Substitute `<PREFIX>`.
+
+```bash
+npx nx g @nx/angular:library shared/angular \
+  --prefix=smart-<PREFIX> --unitTestRunner=jest --linter=eslint \
+  --buildable --interactive=false
+```
+
+The base lib exports ONLY the SSR environment infra (`environment` + `EnvironmentService`).
+NO feature UI components/services/models/pipes/interceptors/directives — `lib/` folders are
+empty placeholders the module skills fill in later.
+
+> The reference's generated `ng-package.json` `dest` and `jest.config.ts` `coverageDirectory`
+> point at `packages/shared/angular` (a generator leftover). Normalize both to
+> `libs/shared/angular` as shown below.
+
+---
+
+## `libs/shared/angular/src/index.ts` (overwrite — minimal barrel)
+
+```ts
+export * from './lib/environments/environment';
+export * from './lib/services/environment/environment.service';
+```
+
+## `libs/shared/angular/src/lib/environments/environment.ts` (create)
+
+```ts
+export const environment = {
+  production: false,
+  version:
+    typeof window !== 'undefined' && (window as any)['env']
+      ? (window as any)['env']['version']
+      : process.env['APP_VERSION'],
+  apiUrl:
+    typeof window !== 'undefined' && (window as any)['env']
+      ? (window as any)['env']['apiUrl']
+      : process.env['API_URL'],
+  siteUrl:
+    typeof window !== 'undefined' && (window as any)['env']
+      ? (window as any)['env']['siteUrl']
+      : process.env['SITE_URL'],
+};
+```
+
+## `libs/shared/angular/src/lib/environments/environment.prod.ts` (create)
+
+```ts
+export const environment = {
+  production: true,
+  version:
+    typeof window !== 'undefined' && (window as any)['env']
+      ? (window as any)['env']['version']
+      : process.env['APP_VERSION'],
+  apiUrl:
+    typeof window !== 'undefined' && (window as any)['env']
+      ? (window as any)['env']['apiUrl']
+      : process.env['API_URL'] || 'http://localhost:0/',
+  siteUrl:
+    typeof window !== 'undefined' && (window as any)['env']
+      ? (window as any)['env']['siteUrl']
+      : process.env['SITE_URL'],
+};
+```
+
+## `libs/shared/angular/src/lib/services/environment/environment.service.ts` (create)
+
+```ts
+import { isPlatformServer } from '@angular/common';
+import {
+  Injectable,
+  PLATFORM_ID,
+  inject,
+  TransferState,
+  makeStateKey,
+} from '@angular/core';
+
+import { environment } from '../../environments/environment';
+
+const ENV_KEY = makeStateKey<any>('environment');
+
+@Injectable({ providedIn: 'root' })
+export class EnvironmentService {
+  private platformId = inject(PLATFORM_ID);
+  private transferState = inject(TransferState);
+
+  static initFromProcessEnv(): void {
+    if (process.env['API_URL']) {
+      environment.apiUrl = process.env['API_URL'];
+    }
+    if (process.env['APP_VERSION'] || process.env['VERSION']) {
+      environment.version =
+        process.env['APP_VERSION'] ||
+        process.env['VERSION'] ||
+        environment.version;
+    }
+    if (process.env['SITE_URL']) {
+      environment.siteUrl = process.env['SITE_URL'];
+    }
+  }
+
+  init(): void {
+    if (isPlatformServer(this.platformId)) {
+      EnvironmentService.initFromProcessEnv();
+      this.transferState.set(ENV_KEY, environment);
+    } else {
+      const env = this.transferState.get(ENV_KEY, {} as any);
+
+      if (env?.apiUrl) {
+        environment.apiUrl = env.apiUrl;
+        environment.version = env.version;
+        environment.siteUrl = env.siteUrl;
+      } else {
+        const windowEnv = (window as unknown as Record<string, any>)['env'];
+        if (windowEnv?.apiUrl) {
+          environment.apiUrl = windowEnv.apiUrl;
+          environment.version = windowEnv.version;
+          environment.siteUrl = windowEnv.siteUrl;
+        } else {
+          throw new Error('Environment variables not set!');
+        }
+      }
+    }
+  }
+}
+```
+
+## Empty `lib/` placeholders
+
+Create empty dirs with a `.gitkeep` each (the module skills populate them):
+`src/lib/components`, `src/lib/services` (already has `environment/`), `src/lib/models`,
+`src/lib/pipes`, `src/lib/interceptors`, `src/lib/directives`, `src/lib/tools`.
+
+---
+
+## `libs/shared/angular/project.json` (overwrite)
+
+```json
+{
+  "name": "shared-angular",
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "projectType": "library",
+  "sourceRoot": "libs/shared/angular/src",
+  "prefix": "smart-<PREFIX>",
+  "tags": [],
+  "targets": {
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "options": {
+        "lintFilePatterns": [
+          "libs/shared/angular/src/**/*.ts",
+          "libs/shared/angular/src/**/*.html"
+        ]
+      }
+    },
+    "test": {
+      "executor": "@nx/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/libs/shared/angular"],
+      "options": {
+        "jestConfig": "libs/shared/angular/jest.config.ts",
+        "passWithNoTests": true,
+        "tsConfig": "libs/shared/angular/tsconfig.spec.json"
+      }
+    },
+    "build": {
+      "executor": "@nx/angular:package",
+      "outputs": ["{workspaceRoot}/dist/{projectRoot}"],
+      "options": {
+        "project": "libs/shared/angular/ng-package.json",
+        "tsConfig": "libs/shared/angular/tsconfig.lib.json"
+      },
+      "configurations": {
+        "production": {
+          "tsConfig": "libs/shared/angular/tsconfig.lib.prod.json"
+        },
+        "development": {}
+      },
+      "defaultConfiguration": "production"
+    },
+    "storybook": {
+      "executor": "@storybook/angular:start-storybook",
+      "options": {
+        "port": 4400,
+        "configDir": "libs/shared/angular/.storybook",
+        "browserTarget": "shared-angular:build-storybook",
+        "compodoc": false
+      }
+    },
+    "build-storybook": {
+      "executor": "@storybook/angular:build-storybook",
+      "outputs": ["{options.outputDir}"],
+      "options": {
+        "outputDir": "dist/storybook/angular",
+        "configDir": "libs/shared/angular/.storybook",
+        "browserTarget": "shared-angular:build-storybook",
+        "compodoc": false
+      }
+    }
+  }
+}
+```
+
+## `libs/shared/angular/ng-package.json` (overwrite — normalized dest)
+
+```json
+{
+  "$schema": "../../../node_modules/ng-packagr/ng-package.schema.json",
+  "dest": "../../../dist/libs/shared/angular",
+  "lib": {
+    "entryFile": "src/index.ts"
+  }
+}
+```
+
+## `libs/shared/angular/package.json`
+
+```json
+{
+  "name": "@<PREFIX>/angular",
+  "version": "1.0.0"
+}
+```
+
+## `libs/shared/angular/jest.config.ts` (overwrite — normalized paths)
+
+```ts
+export default {
+  displayName: 'angular',
+  preset: '../../../jest.preset.js',
+  setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
+  coverageDirectory: '../../../coverage/libs/shared/angular',
+  transform: {
+    '^.+\\.(ts|mjs|js|html)$': [
+      'jest-preset-angular',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        stringifyContentPathRegex: '\\.(html|svg)$',
+        diagnostics: false,
+      },
+    ],
+  },
+  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
+  snapshotSerializers: [
+    'jest-preset-angular/build/serializers/no-ng-attributes',
+    'jest-preset-angular/build/serializers/ng-snapshot',
+    'jest-preset-angular/build/serializers/html-comment',
+  ],
+};
+```
+
+## `libs/shared/angular/src/test-setup.ts`
+
+```ts
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+
+setupZoneTestEnv({
+  errorOnUnknownElements: true,
+  errorOnUnknownProperties: true,
+});
+```
+
+---
+
+## tsconfig set
+
+`tsconfig.json`, `tsconfig.lib.json`, `tsconfig.lib.prod.json`, `tsconfig.spec.json` —
+keep as `nx g @nx/angular:library` generated them (they already extend
+`../../../tsconfig.base.json` and enable strict templates). Verify `tsconfig.lib.json` keeps
+`"types": ["node"]` (the SSR env code uses `process.env`).
+
+## `.storybook/`
+
+Keep `nx g`-generated `.storybook/main.ts`, `.storybook/preview.ts`, `.storybook/tsconfig.json`.
+If absent (generator skipped storybook), add a minimal `.storybook/main.ts`:
+
+```ts
+import type { StorybookConfig } from '@storybook/angular';
+
+const config: StorybookConfig = {
+  stories: ['../**/*.@(mdx|stories.@(js|jsx|ts|tsx))'],
+  addons: ['@storybook/addon-essentials', '@storybook/addon-interactions'],
+  framework: { name: '@storybook/angular', options: {} },
+};
+
+export default config;
+```

--- a/packages/shared/claude-plugins/src/plugins/smart/skills/scaffold-nx-workspace/references/patch-delta.md
+++ b/packages/shared/claude-plugins/src/plugins/smart/skills/scaffold-nx-workspace/references/patch-delta.md
@@ -1,0 +1,403 @@
+# Patch delta — workspace config
+
+Apply these after `create-nx-workspace`. Substitute placeholders everywhere:
+
+- `<PREFIX>` — confirmed import-alias prefix.
+- `<BASE_BRANCH>` — confirmed base branch (default `origin/development`).
+- `<WORKSPACE_NAME>` — the workspace folder/name.
+- `<NG_VERSION>` / `<NODE_VERSION>` — resolved in `references/version-resolution.md` (never hardcoded).
+
+All content below is the **generic, feature-stripped** baseline. Version numbers are not pinned here —
+they come from the version-resolution step.
+
+---
+
+## `nx.json` (overwrite)
+
+Drop `nxCloudId`. Set `defaultBase` to `<BASE_BRANCH>`.
+
+```json
+{
+  "$schema": "./node_modules/nx/schemas/nx-schema.json",
+  "defaultBase": "<BASE_BRANCH>",
+  "namedInputs": {
+    "default": ["{projectRoot}/**/*", "sharedGlobals"],
+    "production": [
+      "default",
+      "!{projectRoot}/.eslintrc.json",
+      "!{projectRoot}/eslint.config.mjs",
+      "!{projectRoot}/**/?(*.)+(spec|test).[jt]s?(x)?(.snap)",
+      "!{projectRoot}/tsconfig.spec.json",
+      "!{projectRoot}/jest.config.[jt]s",
+      "!{projectRoot}/src/test-setup.[jt]s",
+      "!{projectRoot}/test-setup.[jt]s",
+      "!{projectRoot}/**/*.spec.[jt]s?(x)",
+      "!{projectRoot}/playwright.config.[jt]s"
+    ],
+    "sharedGlobals": ["{workspaceRoot}/.github/workflows/ci.yml"]
+  },
+  "targetDefaults": {
+    "@angular/build:application": {
+      "cache": true,
+      "dependsOn": ["^build"],
+      "inputs": ["production", "^production"]
+    },
+    "@nx/eslint:lint": {
+      "cache": true,
+      "inputs": [
+        "default",
+        "{workspaceRoot}/.eslintrc.json",
+        "{workspaceRoot}/.eslintignore",
+        "{workspaceRoot}/eslint.config.mjs"
+      ]
+    },
+    "@nx/jest:jest": {
+      "cache": true,
+      "inputs": ["default", "^production", "{workspaceRoot}/jest.preset.js"],
+      "options": { "passWithNoTests": true },
+      "configurations": { "ci": { "ci": true, "codeCoverage": true } }
+    }
+  },
+  "plugins": [
+    { "plugin": "@nx/eslint/plugin", "options": { "targetName": "lint" } }
+  ],
+  "generators": {
+    "@nx/angular:application": {
+      "e2eTestRunner": "playwright",
+      "linter": "eslint",
+      "style": "scss",
+      "unitTestRunner": "jest"
+    },
+    "@nx/angular:library": { "linter": "eslint", "unitTestRunner": "jest" },
+    "@nx/angular:component": { "style": "scss" }
+  }
+}
+```
+
+> Everything defaults to `scss` — the app, generated libs, and generated components — so styling
+> is consistent workspace-wide.
+
+---
+
+## `tsconfig.base.json` (overwrite)
+
+Keep `compilerOptions`; replace `paths` with a **single generic** entry. NO module paths.
+
+```json
+{
+  "compileOnSave": false,
+  "compilerOptions": {
+    "rootDir": ".",
+    "sourceMap": true,
+    "declaration": false,
+    "moduleResolution": "bundler",
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "esModuleInterop": true,
+    "importHelpers": true,
+    "target": "es2022",
+    "module": "es2022",
+    "lib": ["es2020", "dom"],
+    "skipLibCheck": true,
+    "skipDefaultLibCheck": true,
+    "baseUrl": ".",
+    "paths": {
+      "@<PREFIX>/angular": ["libs/shared/angular/src/index.ts"]
+    }
+  },
+  "exclude": ["node_modules", "tmp"]
+}
+```
+
+---
+
+## `eslint.config.mjs` (overwrite)
+
+Thread `<PREFIX>` into the `import/order` `pathGroups`. Keep the storybook block (the base
+shared lib ships `.storybook`).
+
+```js
+// For more info, see https://github.com/storybookjs/eslint-plugin-storybook#configuration-flat-config-format
+import storybook from 'eslint-plugin-storybook';
+
+import nx from '@nx/eslint-plugin';
+import importPlugin from 'eslint-plugin-import';
+
+export default [
+  ...nx.configs['flat/base'],
+  ...nx.configs['flat/typescript'],
+  ...nx.configs['flat/javascript'],
+  {
+    ignores: ['**/dist'],
+  },
+  {
+    plugins: {
+      import: importPlugin,
+    },
+  },
+  {
+    files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
+    rules: {
+      'import/order': [
+        'error',
+        {
+          'newlines-between': 'always',
+          groups: ['external', 'builtin', 'internal'],
+          pathGroups: [
+            {
+              pattern: '@<PREFIX>/**',
+              group: 'external',
+              position: 'after',
+            },
+          ],
+          pathGroupsExcludedImportTypes: [],
+          alphabetize: {
+            order: 'asc',
+            caseInsensitive: true,
+          },
+        },
+      ],
+    },
+  },
+  {
+    files: [
+      '**/*.ts',
+      '**/*.tsx',
+      '**/*.cts',
+      '**/*.mts',
+      '**/*.js',
+      '**/*.jsx',
+      '**/*.cjs',
+      '**/*.mjs',
+    ],
+    // Override or add rules here
+    rules: {},
+  },
+  ...storybook.configs['flat/recommended'],
+];
+```
+
+---
+
+## `jest.preset.js` (overwrite)
+
+```js
+const nxPreset = require('@nx/jest/preset').default;
+
+module.exports = { ...nxPreset };
+```
+
+## `jest.config.ts` (overwrite)
+
+```ts
+import { getJestProjectsAsync } from '@nx/jest';
+
+export default async () => ({
+  projects: await getJestProjectsAsync(),
+});
+```
+
+---
+
+## `.prettierrc` (overwrite)
+
+```json
+{
+  "singleQuote": true
+}
+```
+
+## `.prettierignore` (overwrite — generic lines only)
+
+```
+# Add files here to ignore them from prettier formatting
+/dist
+/coverage
+/.nx/cache
+/.nx/workspace-data
+/.cache
+
+CHANGELOG.md
+CONTRIBUTING.md
+README.md
+
+.angular
+
+# index.html may contain meta tags prettier cannot parse
+apps/web/src/index.html
+```
+
+## `.editorconfig` (overwrite)
+
+```
+# Editor configuration, see http://editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+max_line_length = off
+trim_trailing_whitespace = false
+```
+
+## `.eslintignore` (overwrite)
+
+```
+node_modules
+**/tailwind.config.js
+```
+
+## `.nvmrc` (overwrite)
+
+Write the resolved `<NODE_VERSION>` (from `references/version-resolution.md`):
+
+```
+<NODE_VERSION>
+```
+
+---
+
+## `commitlint.config.js` (create — generic as-is)
+
+Reads `libs/` directory names for `scope-enum`; fully generic.
+
+```js
+const fs = require('fs');
+const path = require('path');
+
+const getDirectories = (source) =>
+  fs
+    .readdirSync(source, { withFileTypes: true })
+    .filter((dirent) => dirent.isDirectory())
+    .map((dirent) => dirent.name);
+
+module.exports = {
+  extends: ['@commitlint/config-conventional'],
+  rules: {
+    'scope-enum': async () => {
+      return [
+        2,
+        'always',
+        [
+          ...getDirectories(path.join(__dirname, 'libs')).filter(
+            (name) => name.indexOf('-e2e') === -1,
+          ),
+          'nx',
+          'github',
+          'docker',
+          'release',
+        ],
+      ];
+    },
+  },
+};
+```
+
+---
+
+## `.husky/` hooks
+
+Initialize husky (`npx husky install`) then create:
+
+### `.husky/commit-msg`
+
+> Reference runs `... lint test build postbuild`. **Drop `postbuild`** (no such target in a fresh scaffold).
+
+```sh
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npx --no -- commitlint --edit "$1"
+npx nx run-many -t lint test build
+```
+
+### `.husky/pre-push` (thread `<BASE_BRANCH>`)
+
+```sh
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+[ -n "$CI" ] && exit 0
+
+npx nx format:check
+
+npx nx affected --target=lint --base=<BASE_BRANCH> --head=HEAD --parallel=3
+npx nx affected --target=test --base=<BASE_BRANCH> --head=HEAD --parallel=3
+npx nx affected --target=build --base=<BASE_BRANCH> --head=HEAD --parallel=3
+```
+
+### `.husky/post-merge`
+
+```sh
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
+
+nvm use 24
+npm i
+```
+
+---
+
+## `package.json`
+
+### Name + scripts
+
+```json
+{
+  "name": "@<PREFIX>/source",
+  "scripts": {
+    "start": "nx serve web",
+    "start:prod": "nx serve web --configuration=production",
+    "postinstall": "husky install",
+    "format": "nx format && nx run-many --target=lint --fix"
+  }
+}
+```
+
+> Omit the reference's `"update"` script (project-specific tooling).
+
+### devDependencies — add the smart plugin + commit tooling
+
+So the seeded `.claude` hooks and commit hooks resolve. Pin none of these to a literal —
+resolve each at run time:
+
+- `@smartsoft001/claude-plugins` → the version currently providing this skill (`npm view @smartsoft001/claude-plugins version`, or the locally installed one).
+- `husky`, `@commitlint/cli`, `@commitlint/config-conventional` → their current published versions (`npm view <pkg> version`), unless `create-nx-workspace` already added compatible ones.
+
+### Toolchain versions — derive, do not pin
+
+**There is no hardcoded version table.** `create-nx-workspace@<NX_LINE>` (the Nx line resolved in
+`references/version-resolution.md`) installs a self-consistent toolchain — Nx packages, jest,
+eslint, typescript, playwright, swc, esbuild, prettier, rxjs, zone.js. **Keep whatever it installs.**
+
+Only reconcile two things, both driven by the confirmed `<NG_VERSION>`:
+
+- **`@angular/*` + `ng-packagr`** — if the bundled Angular differs from `<NG_VERSION>`, set
+  `@angular/{core,common,compiler,forms,platform-browser,platform-server,router}`, `@angular/ssr`,
+  `@angular/cli`, `@angular/build`, `@angular/compiler-cli`, `@angular/language-service` to `<NG_VERSION>`
+  and `ng-packagr` to its matching line (`npm view "ng-packagr@^<NG_MAJOR>" version | tail -1`).
+- **SSR runtime** — ensure `express` and `dotenv` are present (used by `server.ts`); add via
+  `npm view <pkg> version` if the preset did not.
+
+See `references/version-resolution.md` for the resolution commands.
+
+### EXCLUDED — feature deps (never add in the base)
+
+`@smartsoft001*` and `@smartsoft001-mobilems*` **feature** libs (angular, crud-shell-angular,
+domain-core, models, utils, objects-_, articles-_, public-collections-_, …) — keep ONLY
+`@smartsoft001/claude-plugins` (toolchain). Also exclude: `@ngrx/_`, `@ngx-translate/_`,
+`@nestjs/_`, `@thisissoon/angular-masonry`, `masonry-layout`, `leaflet`/`@types/leaflet`,
+`openseadragon`/`@types/openseadragon`, `online-3d-viewer`, `swiper`, `ng-dynamic-component`,
+`ng-lazyload-image`, `ngx-_`(captcha/color-picker/cookie/editor/pagination),`mongodb`,
+`typeorm`, `passport_`, `paypal-rest-sdk`, `xlsx`, `json2csv`, `crypto-js`, `md5`/`@types/md5`,
+`moment`/`moment-timezone`, `socket.io`, `busboy`, `class-validator`, `guid-typescript`,
+`jwt-decode`, `lodash-decorators`, `tailwindcss`/`autoprefixer`/`postcss`/`postcss-url`,
+`reflect-metadata`, `pnpm`.

--- a/packages/shared/claude-plugins/src/plugins/smart/skills/scaffold-nx-workspace/references/version-resolution.md
+++ b/packages/shared/claude-plugins/src/plugins/smart/skills/scaffold-nx-workspace/references/version-resolution.md
@@ -1,0 +1,83 @@
+# Version resolution
+
+Versions are **never hardcoded**. The Angular version is the anchor; everything else is derived
+from it. Resolve it at run time so a scaffold always matches the smartsoft library it integrates with.
+
+Placeholders produced here and consumed by the other references:
+
+- `<NG_VERSION>` — the confirmed Angular version (e.g. `21.2.4`).
+- `<NG_MAJOR>` — its major (e.g. `21`).
+- `<NX_LINE>` — the Nx version range to scaffold with (e.g. `^22`).
+- `<NODE_VERSION>` — the Node version for `.nvmrc` (e.g. `24.5.0`).
+
+## 1. Detect the Angular version the smartsoft library targets
+
+The scaffolded app consumes `@smartsoft001/angular`, so its Angular peer range is the source of truth.
+
+```bash
+# Preferred: the declared Angular peer range
+npm view @smartsoft001/angular peerDependencies.@angular/core
+# Fallbacks
+npm view @smartsoft001/angular dependencies.@angular/core
+# If installed locally in the current environment, read it directly:
+node -p "(p=>p.peerDependencies?.['@angular/core']||p.dependencies?.['@angular/core'])(require('@smartsoft001/angular/package.json'))"
+```
+
+Resolve the range to a concrete version and take its major:
+
+```bash
+# highest published Angular matching the detected range, e.g. ^21.0.0 -> 21.2.4
+npm view "@angular/core@<detected-range>" version | tail -1
+```
+
+→ `<NG_VERSION>`, `<NG_MAJOR>`.
+
+> If `@smartsoft001/angular` cannot be resolved (offline / not published), ask the user for the
+> Angular version outright — never fall back to a baked-in number.
+
+## 2. Confirm with the user
+
+Use `AskUserQuestion`:
+
+> "Use Angular `<NG_VERSION>` (matches `@smartsoft001/angular`)? — or type another version."
+
+Whatever the user confirms becomes `<NG_VERSION>` / `<NG_MAJOR>`. If they override to a different
+major, all derived values below recompute from the new major.
+
+## 3. Derive the rest from the Angular major
+
+- **Nx line `<NX_LINE>` = `^<NG_MAJOR + 1>`.** Nx's major tracks Angular's major + 1
+  (Angular 21 → Nx 22, Angular 20 → Nx 21, Angular 19 → Nx 20, …). Verify the line resolves:
+
+  ```bash
+  npm view "nx@<NX_LINE>" version | tail -1
+  ```
+
+  `create-nx-workspace@<NX_LINE>` then scaffolds the matching Angular line and a compatible
+  jest / eslint / typescript / playwright / swc / esbuild toolchain. **Do not pin those** — keep
+  whatever the generator installs.
+
+- **Node `<NODE_VERSION>`** = a Node LTS within Angular's engine range:
+
+  ```bash
+  npm view "@angular/core@<NG_VERSION>" engines.node
+  ```
+
+  Pick the highest LTS that satisfies the range (e.g. `^20.19 || ^22.12 || ^24` → `24.5.0`). Write it
+  to `.nvmrc`.
+
+- **`@angular/*` alignment.** If the Angular version `create-nx-workspace` installed differs from the
+  confirmed `<NG_VERSION>`, set all Angular packages to `<NG_VERSION>` in the patch step:
+  `@angular/{core,common,compiler,forms,platform-browser,platform-server,router}`, `@angular/ssr`,
+  `@angular/cli`, `@angular/build`, `@angular/compiler-cli`, `@angular/language-service`, and `ng-packagr`
+  (resolve `ng-packagr`'s matching version with `npm view "ng-packagr@^<NG_MAJOR>" version | tail -1`).
+
+- **`@smartsoft001/claude-plugins`** devDep (so the `.claude` hooks resolve) = the version of the plugin
+  that is currently providing this skill (`npm view @smartsoft001/claude-plugins version`, or the locally
+  installed one) — not a fixed number.
+
+## Summary
+
+The only thing this skill decides is the _shape_ (which packages, which conventions). The _numbers_
+come from `@smartsoft001/angular` + the Nx/Angular alignment rule + Angular's own engine range, all at
+run time.

--- a/packages/shared/claude-plugins/src/plugins/smart/skills/scaffold-nx-workspace/scripts/derive-prefix.sh
+++ b/packages/shared/claude-plugins/src/plugins/smart/skills/scaffold-nx-workspace/scripts/derive-prefix.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Propose an import-alias prefix from a workspace folder name.
+#
+# This is a PROPOSAL only — the skill must present the candidate to the user
+# via AskUserQuestion and require explicit confirm/override. The prefix
+# permanently shapes every import (e.g. @<prefix>/angular), so it is never
+# applied without confirmation.
+#
+# Usage: derive-prefix.sh [workspace-folder-name]
+#   Defaults to the basename of the current directory.
+#
+# Heuristic:
+#   - lowercase; non-alphanumeric -> spaces
+#   - drop noise tokens (mobilems, muzeum, museum, projekt, project, app, web,
+#     www, front, frontend, site, deploy)
+#   - multiple remaining tokens -> initials (e.g. "acme art gallery" -> "aag")
+#   - single token -> first 3 letters
+#   - nothing left -> "app"
+set -euo pipefail
+
+raw="${1:-$(basename "$PWD")}"
+
+cleaned="$(printf '%s' "$raw" | tr '[:upper:]' '[:lower:]' | tr -c '[:alnum:]' ' ')"
+
+noise=" mobilems muzeum museum projekt project app web www front frontend site deploy "
+tokens=()
+for tok in $cleaned; do
+  case "$noise" in
+    *" $tok "*) continue ;;
+  esac
+  tokens+=("$tok")
+done
+
+if [ "${#tokens[@]}" -eq 0 ]; then
+  candidate="app"
+elif [ "${#tokens[@]}" -eq 1 ]; then
+  candidate="$(printf '%s' "${tokens[0]}" | cut -c1-3)"
+else
+  candidate=""
+  for tok in "${tokens[@]}"; do
+    candidate="${candidate}$(printf '%s' "$tok" | cut -c1)"
+  done
+fi
+
+printf '%s\n' "$candidate"

--- a/packages/shared/claude-plugins/src/plugins/smart/skills/scaffold-nx-workspace/scripts/verify-scaffold.sh
+++ b/packages/shared/claude-plugins/src/plugins/smart/skills/scaffold-nx-workspace/scripts/verify-scaffold.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Read-only, install-free structural verification of a scaffolded base workspace.
+# Also reused as the self-validation grader spine.
+#
+# Usage: verify-scaffold.sh <workspace-root> <prefix>
+# Exits non-zero if any check fails; prints a PASS/FAIL checklist.
+set -uo pipefail
+
+ROOT="${1:?usage: verify-scaffold.sh <workspace-root> <prefix>}"
+PREFIX="${2:?usage: verify-scaffold.sh <workspace-root> <prefix>}"
+
+fail=0
+pass() { printf '  PASS  %s\n' "$1"; }
+err()  { printf '  FAIL  %s\n' "$1"; fail=1; }
+
+# exists <relative-path> <label>
+exists() {
+  if [ -e "$ROOT/$1" ]; then pass "$2"; else err "$2 (missing: $1)"; fi
+}
+
+# contains <relative-path> <pattern> <label>
+contains() {
+  if [ -f "$ROOT/$1" ] && grep -qF "$2" "$ROOT/$1"; then
+    pass "$3"
+  else
+    err "$3 (expected '$2' in $1)"
+  fi
+}
+
+# absent <relative-path> <pattern> <label>
+absent() {
+  if [ -f "$ROOT/$1" ] && grep -qF "$2" "$ROOT/$1"; then
+    err "$3 (unexpected '$2' in $1)"
+  else
+    pass "$3"
+  fi
+}
+
+# json_parses <relative-path>
+json_parses() {
+  if [ -f "$ROOT/$1" ]; then
+    if node -e "JSON.parse(require('fs').readFileSync(process.argv[1],'utf8'))" "$ROOT/$1" 2>/dev/null; then
+      pass "valid JSON: $1"
+    else
+      err "invalid JSON: $1"
+    fi
+  fi
+}
+
+echo "Verifying scaffold at: $ROOT (prefix: $PREFIX)"
+echo "--- structure ---"
+exists "apps/web/src/main.ts" "apps/web main.ts"
+exists "apps/web/src/main.server.ts" "apps/web main.server.ts"
+exists "apps/web/src/server.ts" "apps/web server.ts"
+exists "apps/web/src/app/app.config.server.ts" "apps/web app.config.server.ts"
+exists "libs/shared/angular/src/index.ts" "shared lib index.ts"
+
+echo "--- config ---"
+contains "tsconfig.base.json" "@$PREFIX/angular" "tsconfig path alias @$PREFIX/angular"
+absent  "tsconfig.base.json" "/domain" "tsconfig has no feature-lib (domain) path aliases"
+absent  "tsconfig.base.json" "/shell/" "tsconfig has no feature-lib (shell) path aliases"
+absent  "nx.json" "nxCloudId" "nx.json has no nxCloudId"
+contains "nx.json" "@angular/build:application" "nx.json build targetDefault"
+contains "nx.json" "@nx/eslint:lint" "nx.json lint targetDefault"
+contains "nx.json" "@nx/jest:jest" "nx.json jest targetDefault"
+contains "eslint.config.mjs" "@$PREFIX/**" "eslint pathGroup @$PREFIX/**"
+
+echo "--- toolchain ---"
+# .nvmrc must exist and hold a version (the value is derived from Angular, not fixed here)
+if [ -f "$ROOT/.nvmrc" ] && tr -d '[:space:]' < "$ROOT/.nvmrc" | grep -qE '^v?[0-9]+(\.[0-9]+){0,2}$'; then
+  pass ".nvmrc holds a Node version ($(tr -d '[:space:]' < "$ROOT/.nvmrc"))"
+else
+  err ".nvmrc holds a Node version"
+fi
+
+echo "--- no feature deps ---"
+for dep in "@ngrx/" "@ngx-translate/" "@nestjs/" "leaflet" "openseadragon" \
+           "masonry-layout" "@thisissoon/angular-masonry" "mongodb" "typeorm" \
+           "tailwindcss" "@smartsoft001/crud-shell-angular" "@smartsoft001-mobilems/"; do
+  absent "package.json" "$dep" "package.json excludes $dep"
+done
+
+echo "--- JSON validity ---"
+json_parses "nx.json"
+json_parses "tsconfig.base.json"
+json_parses "package.json"
+json_parses "apps/web/project.json"
+json_parses "libs/shared/angular/project.json"
+json_parses ".claude/settings.json"
+
+echo "---"
+if [ "$fail" -eq 0 ]; then
+  echo "RESULT: PASS"
+else
+  echo "RESULT: FAIL"
+fi
+exit "$fail"


### PR DESCRIPTION
Adds the smartsoft001-side base Nx workspace skill from FRA-284: wraps create-nx-workspace and patches smartsoft conventions to produce a buildable Angular SSR shell (apps/web + libs/shared/angular), with no feature modules or feature npm packages.

- Angular version inferred from @smartsoft001/angular and confirmed with the user; Nx/Node/toolchain derived to match (no hardcoded versions)
- scss everywhere; generic .claude baseline; bundled references/ + scripts/
- verify-scaffold.sh for install-free structural checks

Refs: FRA-284